### PR TITLE
Update example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ func main() {
   // create new TransIP API SOAP client
   c, err := gotransip.NewSOAPClient(gotransip.ClientConfig{
     AccountName: "accountname",
-    PrivateKey:  "/path/to/api/private.key"
+    PrivateKeyPath:  "/path/to/api/private.key"
   })
   if err != nil {
     panic(err.Error())


### PR DESCRIPTION
### Short description
Update example in `README.md`. The TransIP API SOAP client uses
`PrivateKeyPath` instead of `PrivateKey`.
