### PR TITLE
Add clone vps functions to vps api

### DIFF
--- a/vps/api.go
+++ b/vps/api.go
@@ -102,8 +102,30 @@ func GetCancellableAddonsForVps(c gotransip.Client, vpsName string) ([]Product, 
 
 // TODO: implement orderVps
 // TODO: implement orderVpsInAvailabilityZone
-// TODO: implement cloneVps
-// TODO: implement cloneVpsToAvailabilityZone
+
+// CloneVps clones a Vps
+func CloneVps(c gotransip.Client, vpsName string) error {
+	sr := gotransip.SoapRequest{
+		Service: serviceName,
+		Method:  "cloneVps",
+	}
+	sr.AddArgument("vpsName", vpsName)
+
+	return c.Call(sr, nil)
+}
+
+// CloneVpsToAvailabilityZone clones a Vps to a availability zone
+func CloneVpsToAvailabilityZone(c gotransip.Client, vpsName string, availabilityZone string) error {
+	sr := gotransip.SoapRequest{
+		Service: serviceName,
+		Method:  "cloneVpsToAvailabilityZone",
+	}
+	sr.AddArgument("vpsName", vpsName)
+	sr.AddArgument("availabilityZone", availabilityZone)
+
+	return c.Call(sr, nil)
+}
+
 // TODO: implement orderAddon
 // TODO: implement orderPrivateNetwork
 


### PR DESCRIPTION
### Short description

Add the followings missing functions to `vps/api.go`: `CloneVps` and `CloneVpsToAvailabilityZone`.

I would like to add a test, but could not find a good example for a write action. The PR is tested by cloning a couple of vps on my personal account.

*Note:* I'm fairly new to writing golang. If there are any comments, please let me know!
