### PR TITLE
Fix encoding empty string arrays

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -29,11 +29,11 @@ type Domain struct {
 // EncodeParams returns Domain parameters ready to be used for constructing a signature
 func (d Domain) EncodeParams(prm gotransip.ParamsContainer) {
 	idx := prm.Len()
-	prm.Set(fmt.Sprintf("%d[name]", idx), d.Name)
-	prm.Set(fmt.Sprintf("%d[authCode]", idx), d.AuthorizationCode)
-	prm.Set(fmt.Sprintf("%d[isLocked]", idx), fmt.Sprintf("%t", d.IsLocked))
-	prm.Set(fmt.Sprintf("%d[registrationDate]", idx), d.RegistrationDate.Format("2006-01-02"))
-	prm.Set(fmt.Sprintf("%d[renewalDate]", idx), d.RenewalDate.Format("2006-01-02"))
+	prm.Add(fmt.Sprintf("%d[name]", idx), d.Name)
+	prm.Add(fmt.Sprintf("%d[authCode]", idx), d.AuthorizationCode)
+	prm.Add(fmt.Sprintf("%d[isLocked]", idx), fmt.Sprintf("%t", d.IsLocked))
+	prm.Add(fmt.Sprintf("%d[registrationDate]", idx), d.RegistrationDate.Format("2006-01-02"))
+	prm.Add(fmt.Sprintf("%d[renewalDate]", idx), d.RenewalDate.Format("2006-01-02"))
 	// nameservers
 	for i, e := range d.Nameservers {
 		var ipv4, ipv6 string
@@ -43,43 +43,43 @@ func (d Domain) EncodeParams(prm gotransip.ParamsContainer) {
 		if e.IPv6Address != nil {
 			ipv6 = e.IPv6Address.String()
 		}
-		prm.Set(fmt.Sprintf("%d[nameservers][%d][hostname]", idx, i), e.Hostname)
-		prm.Set(fmt.Sprintf("%d[nameservers][%d][ipv4]", idx, i), ipv4)
-		prm.Set(fmt.Sprintf("%d[nameservers][%d][ipv6]", idx, i), ipv6)
+		prm.Add(fmt.Sprintf("%d[nameservers][%d][hostname]", idx, i), e.Hostname)
+		prm.Add(fmt.Sprintf("%d[nameservers][%d][ipv4]", idx, i), ipv4)
+		prm.Add(fmt.Sprintf("%d[nameservers][%d][ipv6]", idx, i), ipv6)
 	}
 	// contacts
 	for i, e := range d.Contacts {
-		prm.Set(fmt.Sprintf("%d[contacts][%d][type]", idx, i), e.Type)
-		prm.Set(fmt.Sprintf("%d[contacts][%d][firstName]", idx, i), e.FirstName)
-		prm.Set(fmt.Sprintf("%d[contacts][%d][middleName]", idx, i), e.MiddleName)
-		prm.Set(fmt.Sprintf("%d[contacts][%d][lastName]", idx, i), e.LastName)
-		prm.Set(fmt.Sprintf("%d[contacts][%d][companyName]", idx, i), e.CompanyName)
-		prm.Set(fmt.Sprintf("%d[contacts][%d][companyKvk]", idx, i), e.CompanyKvk)
-		prm.Set(fmt.Sprintf("%d[contacts][%d][companyType]", idx, i), e.CompanyType)
-		prm.Set(fmt.Sprintf("%d[contacts][%d][street]", idx, i), e.Street)
-		prm.Set(fmt.Sprintf("%d[contacts][%d][number]", idx, i), e.Number)
-		prm.Set(fmt.Sprintf("%d[contacts][%d][postalCode]", idx, i), e.PostalCode)
-		prm.Set(fmt.Sprintf("%d[contacts][%d][city]", idx, i), e.City)
-		prm.Set(fmt.Sprintf("%d[contacts][%d][phoneNumber]", idx, i), e.PhoneNumber)
-		prm.Set(fmt.Sprintf("%d[contacts][%d][faxNumber]", idx, i), e.FaxNumber)
-		prm.Set(fmt.Sprintf("%d[contacts][%d][email]", idx, i), e.Email)
-		prm.Set(fmt.Sprintf("%d[contacts][%d][country]", idx, i), e.Country)
+		prm.Add(fmt.Sprintf("%d[contacts][%d][type]", idx, i), e.Type)
+		prm.Add(fmt.Sprintf("%d[contacts][%d][firstName]", idx, i), e.FirstName)
+		prm.Add(fmt.Sprintf("%d[contacts][%d][middleName]", idx, i), e.MiddleName)
+		prm.Add(fmt.Sprintf("%d[contacts][%d][lastName]", idx, i), e.LastName)
+		prm.Add(fmt.Sprintf("%d[contacts][%d][companyName]", idx, i), e.CompanyName)
+		prm.Add(fmt.Sprintf("%d[contacts][%d][companyKvk]", idx, i), e.CompanyKvk)
+		prm.Add(fmt.Sprintf("%d[contacts][%d][companyType]", idx, i), e.CompanyType)
+		prm.Add(fmt.Sprintf("%d[contacts][%d][street]", idx, i), e.Street)
+		prm.Add(fmt.Sprintf("%d[contacts][%d][number]", idx, i), e.Number)
+		prm.Add(fmt.Sprintf("%d[contacts][%d][postalCode]", idx, i), e.PostalCode)
+		prm.Add(fmt.Sprintf("%d[contacts][%d][city]", idx, i), e.City)
+		prm.Add(fmt.Sprintf("%d[contacts][%d][phoneNumber]", idx, i), e.PhoneNumber)
+		prm.Add(fmt.Sprintf("%d[contacts][%d][faxNumber]", idx, i), e.FaxNumber)
+		prm.Add(fmt.Sprintf("%d[contacts][%d][email]", idx, i), e.Email)
+		prm.Add(fmt.Sprintf("%d[contacts][%d][country]", idx, i), e.Country)
 	}
 	// dnsEntries
 	for i, e := range d.DNSEntries {
-		prm.Set(fmt.Sprintf("%d[dnsEntries][%d][name]", idx, i), e.Name)
-		prm.Set(fmt.Sprintf("%d[dnsEntries][%d][expire]", idx, i), fmt.Sprintf("%d", e.TTL))
-		prm.Set(fmt.Sprintf("%d[dnsEntries][%d][type]", idx, i), string(e.Type))
-		prm.Set(fmt.Sprintf("%d[dnsEntries][%d][content]", idx, i), e.Content)
+		prm.Add(fmt.Sprintf("%d[dnsEntries][%d][name]", idx, i), e.Name)
+		prm.Add(fmt.Sprintf("%d[dnsEntries][%d][expire]", idx, i), fmt.Sprintf("%d", e.TTL))
+		prm.Add(fmt.Sprintf("%d[dnsEntries][%d][type]", idx, i), string(e.Type))
+		prm.Add(fmt.Sprintf("%d[dnsEntries][%d][content]", idx, i), e.Content)
 	}
 	// branding
-	prm.Set(fmt.Sprintf("%d[branding][companyName]", idx), d.Branding.CompanyName)
-	prm.Set(fmt.Sprintf("%d[branding][supportEmail]", idx), d.Branding.SupportEmail)
-	prm.Set(fmt.Sprintf("%d[branding][companyUrl]", idx), d.Branding.CompanyURL)
-	prm.Set(fmt.Sprintf("%d[branding][termsOfUsageUrl]", idx), d.Branding.TermsOfUsageURL)
-	prm.Set(fmt.Sprintf("%d[branding][bannerLine1]", idx), d.Branding.BannerLine1)
-	prm.Set(fmt.Sprintf("%d[branding][bannerLine2]", idx), d.Branding.BannerLine2)
-	prm.Set(fmt.Sprintf("%d[branding][bannerLine3]", idx), d.Branding.BannerLine3)
+	prm.Add(fmt.Sprintf("%d[branding][companyName]", idx), d.Branding.CompanyName)
+	prm.Add(fmt.Sprintf("%d[branding][supportEmail]", idx), d.Branding.SupportEmail)
+	prm.Add(fmt.Sprintf("%d[branding][companyUrl]", idx), d.Branding.CompanyURL)
+	prm.Add(fmt.Sprintf("%d[branding][termsOfUsageUrl]", idx), d.Branding.TermsOfUsageURL)
+	prm.Add(fmt.Sprintf("%d[branding][bannerLine1]", idx), d.Branding.BannerLine1)
+	prm.Add(fmt.Sprintf("%d[branding][bannerLine2]", idx), d.Branding.BannerLine2)
+	prm.Add(fmt.Sprintf("%d[branding][bannerLine3]", idx), d.Branding.BannerLine3)
 }
 
 // EncodeArgs returns Domain XML body ready to be passed in the SOAP call
@@ -161,9 +161,9 @@ func (n Nameservers) EncodeParams(prm gotransip.ParamsContainer) {
 		if e.IPv6Address != nil {
 			ipv6 = e.IPv6Address.String()
 		}
-		prm.Set(fmt.Sprintf("%d[%d][hostname]", idx, i), e.Hostname)
-		prm.Set(fmt.Sprintf("%d[%d][ipv4]", idx, i), ipv4)
-		prm.Set(fmt.Sprintf("%d[%d][ipv6]", idx, i), ipv6)
+		prm.Add(fmt.Sprintf("%d[%d][hostname]", idx, i), e.Hostname)
+		prm.Add(fmt.Sprintf("%d[%d][ipv4]", idx, i), ipv4)
+		prm.Add(fmt.Sprintf("%d[%d][ipv6]", idx, i), ipv6)
 	}
 }
 
@@ -225,10 +225,10 @@ type DNSEntries []DNSEntry
 func (d DNSEntries) EncodeParams(prm gotransip.ParamsContainer) {
 	idx := prm.Len()
 	for i, e := range d {
-		prm.Set(fmt.Sprintf("%d[%d][name]", idx, i), e.Name)
-		prm.Set(fmt.Sprintf("%d[%d][expire]", idx, i), fmt.Sprintf("%d", e.TTL))
-		prm.Set(fmt.Sprintf("%d[%d][type]", idx, i), string(e.Type))
-		prm.Set(fmt.Sprintf("%d[%d][content]", idx, i), e.Content)
+		prm.Add(fmt.Sprintf("%d[%d][name]", idx, i), e.Name)
+		prm.Add(fmt.Sprintf("%d[%d][expire]", idx, i), fmt.Sprintf("%d", e.TTL))
+		prm.Add(fmt.Sprintf("%d[%d][type]", idx, i), string(e.Type))
+		prm.Add(fmt.Sprintf("%d[%d][content]", idx, i), e.Content)
 	}
 }
 
@@ -288,13 +288,13 @@ type Branding struct {
 // EncodeParams returns WhoisContacts parameters ready to be used for constructing a signature
 func (b Branding) EncodeParams(prm gotransip.ParamsContainer) {
 	idx := prm.Len()
-	prm.Set(fmt.Sprintf("%d[companyName]", idx), b.CompanyName)
-	prm.Set(fmt.Sprintf("%d[supportEmail]", idx), b.SupportEmail)
-	prm.Set(fmt.Sprintf("%d[companyUrl]", idx), b.CompanyURL)
-	prm.Set(fmt.Sprintf("%d[termsOfUsageUrl]", idx), b.TermsOfUsageURL)
-	prm.Set(fmt.Sprintf("%d[bannerLine1]", idx), b.BannerLine1)
-	prm.Set(fmt.Sprintf("%d[bannerLine2]", idx), b.BannerLine2)
-	prm.Set(fmt.Sprintf("%d[bannerLine3]", idx), b.BannerLine3)
+	prm.Add(fmt.Sprintf("%d[companyName]", idx), b.CompanyName)
+	prm.Add(fmt.Sprintf("%d[supportEmail]", idx), b.SupportEmail)
+	prm.Add(fmt.Sprintf("%d[companyUrl]", idx), b.CompanyURL)
+	prm.Add(fmt.Sprintf("%d[termsOfUsageUrl]", idx), b.TermsOfUsageURL)
+	prm.Add(fmt.Sprintf("%d[bannerLine1]", idx), b.BannerLine1)
+	prm.Add(fmt.Sprintf("%d[bannerLine2]", idx), b.BannerLine2)
+	prm.Add(fmt.Sprintf("%d[bannerLine3]", idx), b.BannerLine3)
 }
 
 // EncodeArgs returns Branding XML body ready to be passed in the SOAP call
@@ -358,21 +358,21 @@ type WhoisContacts []WhoisContact
 func (w WhoisContacts) EncodeParams(prm gotransip.ParamsContainer) {
 	idx := prm.Len()
 	for i, e := range w {
-		prm.Set(fmt.Sprintf("%d[%d][type]", idx, i), e.Type)
-		prm.Set(fmt.Sprintf("%d[%d][firstName]", idx, i), e.FirstName)
-		prm.Set(fmt.Sprintf("%d[%d][middleName]", idx, i), e.MiddleName)
-		prm.Set(fmt.Sprintf("%d[%d][lastName]", idx, i), e.LastName)
-		prm.Set(fmt.Sprintf("%d[%d][companyName]", idx, i), e.CompanyName)
-		prm.Set(fmt.Sprintf("%d[%d][companyKvk]", idx, i), e.CompanyKvk)
-		prm.Set(fmt.Sprintf("%d[%d][companyType]", idx, i), e.CompanyType)
-		prm.Set(fmt.Sprintf("%d[%d][street]", idx, i), e.Street)
-		prm.Set(fmt.Sprintf("%d[%d][number]", idx, i), e.Number)
-		prm.Set(fmt.Sprintf("%d[%d][postalCode]", idx, i), e.PostalCode)
-		prm.Set(fmt.Sprintf("%d[%d][city]", idx, i), e.City)
-		prm.Set(fmt.Sprintf("%d[%d][phoneNumber]", idx, i), e.PhoneNumber)
-		prm.Set(fmt.Sprintf("%d[%d][faxNumber]", idx, i), e.FaxNumber)
-		prm.Set(fmt.Sprintf("%d[%d][email]", idx, i), e.Email)
-		prm.Set(fmt.Sprintf("%d[%d][country]", idx, i), e.Country)
+		prm.Add(fmt.Sprintf("%d[%d][type]", idx, i), e.Type)
+		prm.Add(fmt.Sprintf("%d[%d][firstName]", idx, i), e.FirstName)
+		prm.Add(fmt.Sprintf("%d[%d][middleName]", idx, i), e.MiddleName)
+		prm.Add(fmt.Sprintf("%d[%d][lastName]", idx, i), e.LastName)
+		prm.Add(fmt.Sprintf("%d[%d][companyName]", idx, i), e.CompanyName)
+		prm.Add(fmt.Sprintf("%d[%d][companyKvk]", idx, i), e.CompanyKvk)
+		prm.Add(fmt.Sprintf("%d[%d][companyType]", idx, i), e.CompanyType)
+		prm.Add(fmt.Sprintf("%d[%d][street]", idx, i), e.Street)
+		prm.Add(fmt.Sprintf("%d[%d][number]", idx, i), e.Number)
+		prm.Add(fmt.Sprintf("%d[%d][postalCode]", idx, i), e.PostalCode)
+		prm.Add(fmt.Sprintf("%d[%d][city]", idx, i), e.City)
+		prm.Add(fmt.Sprintf("%d[%d][phoneNumber]", idx, i), e.PhoneNumber)
+		prm.Add(fmt.Sprintf("%d[%d][faxNumber]", idx, i), e.FaxNumber)
+		prm.Add(fmt.Sprintf("%d[%d][email]", idx, i), e.Email)
+		prm.Add(fmt.Sprintf("%d[%d][country]", idx, i), e.Country)
 	}
 }
 

--- a/sign_test.go
+++ b/sign_test.go
@@ -35,11 +35,11 @@ AeN9hjadhpK2ql+X9qnmkw==
 -----END PRIVATE KEY-----`
 
 	params := &soapParams{}
-	params.Set("__method", "getHaip")
-	params.Set("__service", "HaipService")
-	params.Set("__hostname", "api.transip.nl")
-	params.Set("__timestamp", "1534839460")
-	params.Set("__nonce", "5b7bcab97f1a98.77032926")
+	params.Add("__method", "getHaip")
+	params.Add("__service", "HaipService")
+	params.Add("__hostname", "api.transip.nl")
+	params.Add("__timestamp", 1534839460)
+	params.Add("__nonce", "5b7bcab97f1a98.77032926")
 
 	signature, err := signWithKey(params, []byte(key))
 	if err != nil {

--- a/soap.go
+++ b/soap.go
@@ -403,21 +403,14 @@ type TestParamsContainer struct {
 	Prm string
 }
 
-// Set just make sure we use Len(), key and value in the result so it can be
+// Add just makes sure we use Len(), key and value in the result so it can be
 // tested
-func (t *TestParamsContainer) Set(key, value string) {
+func (t *TestParamsContainer) Add(key string, value interface{}) {
 	var prefix string
 	if t.Len() > 0 {
 		prefix = "&"
 	}
 	t.Prm = t.Prm + prefix + fmt.Sprintf("%d%s=%s", t.Len(), key, value)
-}
-
-// SetMulti is a wrapper for Set to use with string arrays
-func (t *TestParamsContainer) SetMulti(key string, value []string) {
-	for i, x := range value {
-		t.Set(fmt.Sprintf("%s[%d]", key, i), x)
-	}
 }
 
 // Len returns current length of test data in TestParamsContainer

--- a/soap.go
+++ b/soap.go
@@ -76,69 +76,76 @@ type paramsEncoder interface {
 // SOAP parameters
 type ParamsContainer interface {
 	Len() int
-	Set(string, string)
-	SetMulti(string, []string)
+	Add(string, interface{})
 }
 
-// SoapParams is a utility to make sure our key/value pairs are glued together
-// in the same order as we set them
-// the TransIP API requires this order for verifying the signature
+// soapParams is a utility to make sure parameter data is encoded into a query
+// in the same order as we set them. The TransIP API requires this order for
+// verifying the signature
 type soapParams struct {
 	keys   []string
-	values []string
+	values []interface{}
 }
 
-// Set sets value v for key k in this SoapParams
-// will overwrite a previously set value for key k
-func (s *soapParams) Set(k, v string) {
-	// go over existing keys and see if key already exists
-	for i, x := range s.keys {
-		if x == k {
-			s.values[i] = v
-			return
-		}
+// Add adds parameter data to the end of this SoapParams
+func (s *soapParams) Add(k string, v interface{}) {
+	if s.keys == nil {
+		s.keys = make([]string, 0)
 	}
 
-	// key didn't exist, set it
+	if s.values == nil {
+		s.values = make([]interface{}, 0)
+	}
+
 	s.keys = append(s.keys, k)
 	s.values = append(s.values, v)
 }
 
-// SetMulti wraps around Set to easily set array values
-func (s *soapParams) SetMulti(k string, v []string) {
-	for i, x := range v {
-		s.Set(fmt.Sprintf("%s[%d]", k, i), x)
-	}
-}
-
-// Get returns value for key k or error when key was not found
-func (s soapParams) Get(k string) (string, error) {
-	for i, x := range s.keys {
-		if x == k {
-			return s.values[i], nil
-		}
-	}
-
-	return "", fmt.Errorf("no value found for key %s", k)
-}
-
-// Len returns amount of key/value pairs set in this SoapParams
+// Len returns amount of parameters set in this SoapParams
 func (s soapParams) Len() int {
 	return len(s.keys)
 }
 
-// Encode is similar to url.Values.Encode() but without sorting of the keys
+// Encode returns a URL-like query string that can be used to generate a request's
+// signature. It's similar to url.Values.Encode() but without sorting of the keys
+// and based on the value's type it tries to encode accordingly.
 func (s soapParams) Encode() string {
 	var buf bytes.Buffer
+	var key string
 
-	for i, k := range s.keys {
-		v := s.values[i]
-		if buf.Len() > 0 {
+	for i, v := range s.values {
+		// if this is not the first parameter, prefix with &
+		if i > 0 {
 			buf.WriteString("&")
 		}
 
-		buf.WriteString(k + "=")
-		buf.WriteString(url.QueryEscape(v))
+		// for empty data fields, don't encode anything
+		if v == nil {
+			continue
+		}
+
+		key = s.keys[i]
+
+		switch v.(type) {
+		case []string:
+			c := v.([]string)
+			for j, cc := range c {
+				if j > 0 {
+					buf.WriteString("&")
+				}
+				buf.WriteString(fmt.Sprintf("%s[%d]=", key, j))
+				buf.WriteString(strings.Replace(url.QueryEscape(cc), "+", "%20", -1))
+			}
+		case string:
+			c := v.(string)
+			buf.WriteString(fmt.Sprintf("%s=", key))
+			buf.WriteString(strings.Replace(url.QueryEscape(c), "+", "%20", -1))
+		case int, int8, int16, int32, int64:
+			buf.WriteString(fmt.Sprintf("%s=", key))
+			buf.WriteString(fmt.Sprintf("%d", v))
+		default:
+			continue
+		}
 	}
 
 	return buf.String()
@@ -195,18 +202,18 @@ func (sr *SoapRequest) AddArgument(key string, value interface{}) {
 
 	switch value.(type) {
 	case []string:
-		sr.params.SetMulti(fmt.Sprintf("%d", sr.params.Len()), value.([]string))
+		sr.params.Add(fmt.Sprintf("%d", sr.params.Len()), value)
 		sr.args = append(sr.args, getSOAPArg(key, value))
 	case string:
-		sr.params.Set(fmt.Sprintf("%d", sr.params.Len()), value.(string))
+		sr.params.Add(fmt.Sprintf("%d", sr.params.Len()), value)
 		sr.args = append(sr.args, getSOAPArg(key, value.(string)))
 	case int, int8, int16, int32, int64:
-		sr.params.Set(fmt.Sprintf("%d", sr.params.Len()), fmt.Sprintf("%d", value))
+		sr.params.Add(fmt.Sprintf("%d", sr.params.Len()), value)
 		sr.args = append(sr.args, getSOAPArg(key, fmt.Sprintf("%d", value)))
 	default:
 		// check if value implements the String interface
 		if str, ok := value.(fmt.Stringer); ok {
-			sr.params.Set(fmt.Sprintf("%d", sr.params.Len()), str.String())
+			sr.params.Add(fmt.Sprintf("%d", sr.params.Len()), str.String())
 			sr.args = append(sr.args, getSOAPArg(key, str.String()))
 		}
 	}
@@ -269,11 +276,11 @@ func (s soapClient) httpReqForSoapRequest(req SoapRequest) (*http.Request, error
 	}
 	// TransIP API is quite picky on the order of the parameters
 	// so don't change anything in the order below
-	req.params.Set("__method", req.Method)
-	req.params.Set("__service", req.Service)
-	req.params.Set("__hostname", transipAPIHost)
-	req.params.Set("__timestamp", timestamp)
-	req.params.Set("__nonce", nonce)
+	req.params.Add("__method", req.Method)
+	req.params.Add("__service", req.Service)
+	req.params.Add("__hostname", transipAPIHost)
+	req.params.Add("__timestamp", timestamp)
+	req.params.Add("__nonce", nonce)
 
 	signature, err := signWithKey(req.params, s.PrivateKey)
 	if err != nil {

--- a/soap_test.go
+++ b/soap_test.go
@@ -282,8 +282,8 @@ func TestSoapRequestGetEnvelope(t *testing.T) {
 func TestTestParamsContainer(t *testing.T) {
 	prm := TestParamsContainer{}
 
-	prm.Set("foo", "bar")
-	prm.SetMulti("bar", []string{"boo", "far"})
+	prm.Add("foo", "bar")
+	prm.Add("bar", []string{"boo", "far"})
 
-	assert.Equal(t, "0foo=bar&8bar[0]=boo&20bar[1]=far", prm.Prm)
+	assert.Equal(t, "0foo=bar&8bar=[boo far]", prm.Prm)
 }

--- a/soap_test.go
+++ b/soap_test.go
@@ -125,67 +125,33 @@ AeN9hjadhpK2ql+X9qnmkw==
 	}
 }
 
-func TestSoapParamsSet(t *testing.T) {
+func TestSoapParamsAdd(t *testing.T) {
 	p := soapParams{}
 	// empty soapParams
 	assert.Equal(t, 0, p.Len())
 
 	// set first pair
-	p.Set("foo", "bar")
-	assert.Equal(t, 1, p.Len())
-	assert.Equal(t, "foo", p.keys[0])
-	assert.Equal(t, "bar", p.values[0])
-
-	// set second pair
-	p.Set("foo2", "bar2")
-	assert.Equal(t, 2, p.Len())
-	assert.Equal(t, "foo2", p.keys[1])
-	assert.Equal(t, "bar2", p.values[1])
-
-	// override first pair
-	p.Set("foo", "bar3")
-	assert.Equal(t, 2, p.Len())
-	assert.Equal(t, "foo", p.keys[0])
-	assert.Equal(t, "bar3", p.values[0])
-}
-
-func TestSoapParamsSetMulti(t *testing.T) {
-	p := soapParams{}
-
-	p.SetMulti("foo", []string{
-		"foo", "bar", "baz",
-	})
-	p.Set("bar", "baz")
-	assert.Equal(t, 4, p.Len())
-	assert.Equal(t, "foo[0]=foo&foo[1]=bar&foo[2]=baz&bar=baz", p.Encode())
-}
-
-func TestSoapParamsGet(t *testing.T) {
-	var v string
-	var err error
-
-	p := soapParams{}
-	v, err = p.Get("foo")
-	assert.Errorf(t, err, "expected error, got %s", v)
-
-	p.Set("foo", "bar")
-	v, err = p.Get("foo")
-	assert.NoError(t, err)
-	assert.Equal(t, "bar", v)
-
-	p.Set("foo", "bar2")
-	v, err = p.Get("foo")
-	assert.NoError(t, err)
-	assert.Equal(t, "bar2", v)
+	p.Add("foo", "foo")
+	p.Add("bar", "bar")
+	p.Add("baz", 1337)
+	assert.Equal(t, 3, p.Len())
 }
 
 func TestSoapParamsEncode(t *testing.T) {
 	p := soapParams{}
-	p.Set("foo", "bar+bar")
-	p.Set("bar", "bar bar")
-	p.Set("baz", "YmFyCg==")
+	p.Add("0", "bar+bar")
+	p.Add("1", "bar bar")
+	p.Add("2", "YmFyCg==")
+	p.Add("3", "")
+	p.Add("4", []string{"foo", "bar"})
+	p.Add("5", []string{})
+	p.Add("6", []string{"foo"})
+	p.Add("7", 6)
+	p.Add("8", "86400")
+	p.Add("__method", "foo")
+	p.Add("__service", "bar")
 
-	assert.Equal(t, "foo=bar%2Bbar&bar=bar+bar&baz=YmFyCg%3D%3D", p.Encode())
+	assert.Equal(t, "0=bar%2Bbar&1=bar%20bar&2=YmFyCg%3D%3D&3=&4[0]=foo&4[1]=bar&&6[0]=foo&7=6&8=86400&__method=foo&__service=bar", p.Encode())
 }
 
 func TestGetSOAPArgs(t *testing.T) {
@@ -253,7 +219,7 @@ func TestSoapRequestAddArgument(t *testing.T) {
 	sr.AddArgument("ipAddress", net.ParseIP("1.2.3.4"))
 	sr.AddArgument("sourcePort", 86400)
 
-	assert.Equal(t, "0=test&1[0]=test-vps&1[1]=test-vps2&3=1.2.3.4&4=86400", sr.params.Encode())
+	assert.Equal(t, "0=test&1[0]=test-vps&1[1]=test-vps2&2=1.2.3.4&3=86400", sr.params.Encode())
 	assert.Equal(t, []string{
 		"<haipName xsi:type=\"xsd:string\">test</haipName>",
 		"<vpsNames SOAP-ENC:arrayType=\"xsd:string[2]\" xsi:type=\"ns1:ArrayOfString\"><item xsi:type=\"xsd:string\">test-vps</item><item xsi:type=\"xsd:string\">test-vps2</item></vpsNames>",
@@ -268,8 +234,8 @@ type TestParamsEncoder struct {
 }
 
 func (t TestParamsEncoder) EncodeParams(prm ParamsContainer) {
-	prm.Set(fmt.Sprintf("%d[key]", prm.Len()), t.key)
-	prm.Set(fmt.Sprintf("%d[value]", prm.Len()), t.value)
+	prm.Add("0[key]", t.key)
+	prm.Add("1[value]", t.value)
 }
 
 func (t TestParamsEncoder) EncodeArgs(key string) string {

--- a/soap_test.go
+++ b/soap_test.go
@@ -1,7 +1,6 @@
 package gotransip
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -129,39 +128,25 @@ AeN9hjadhpK2ql+X9qnmkw==
 func TestSoapParamsSet(t *testing.T) {
 	p := soapParams{}
 	// empty soapParams
-	if p.Len() != 0 {
-		t.Errorf("expected empty params, got length %d", p.Len())
-	}
+	assert.Equal(t, 0, p.Len())
 
 	// set first pair
 	p.Set("foo", "bar")
-	if p.Len() != 1 {
-		t.Errorf("expected 1 entry, got length %d", p.Len())
-	} else if p.keys[0] != "foo" {
-		t.Errorf("expected foo, got %s", p.keys[0])
-	} else if p.values[0] != "bar" {
-		t.Errorf("expected bar, got %s", p.values[0])
-	}
+	assert.Equal(t, 1, p.Len())
+	assert.Equal(t, "foo", p.keys[0])
+	assert.Equal(t, "bar", p.values[0])
 
 	// set second pair
 	p.Set("foo2", "bar2")
-	if p.Len() != 2 {
-		t.Errorf("expected 2 entries, got length %d", p.Len())
-	} else if p.keys[1] != "foo2" {
-		t.Errorf("expected foo2, got %s", p.keys[1])
-	} else if p.values[1] != "bar2" {
-		t.Errorf("expected bar2, got %s", p.values[1])
-	}
+	assert.Equal(t, 2, p.Len())
+	assert.Equal(t, "foo2", p.keys[1])
+	assert.Equal(t, "bar2", p.values[1])
 
 	// override first pair
 	p.Set("foo", "bar3")
-	if p.Len() != 2 {
-		t.Errorf("expected 2 entries, got length %d", p.Len())
-	} else if p.keys[0] != "foo" {
-		t.Errorf("expected foo, got %s", p.keys[0])
-	} else if p.values[0] != "bar3" {
-		t.Errorf("expected bar, got %s", p.values[0])
-	}
+	assert.Equal(t, 2, p.Len())
+	assert.Equal(t, "foo", p.keys[0])
+	assert.Equal(t, "bar3", p.values[0])
 }
 
 func TestSoapParamsSetMulti(t *testing.T) {
@@ -171,34 +156,27 @@ func TestSoapParamsSetMulti(t *testing.T) {
 		"foo", "bar", "baz",
 	})
 	p.Set("bar", "baz")
-
-	fixt := "foo[0]=foo&foo[1]=bar&foo[2]=baz&bar=baz"
-	if p.Len() != 4 {
-		t.Errorf("expected 4 entries, got length %d", p.Len())
-	} else if result := p.Encode(); result != fixt {
-		t.Errorf("encoded params do not match\nexpected: %s\nactual:   %s\n", fixt, result)
-	}
+	assert.Equal(t, 4, p.Len())
+	assert.Equal(t, "foo[0]=foo&foo[1]=bar&foo[2]=baz&bar=baz", p.Encode())
 }
 
 func TestSoapParamsGet(t *testing.T) {
+	var v string
+	var err error
+
 	p := soapParams{}
-	if v, err := p.Get("foo"); err == nil {
-		t.Errorf("expected error, got %s", v)
-	}
+	v, err = p.Get("foo")
+	assert.Errorf(t, err, "expected error, got %s", v)
 
 	p.Set("foo", "bar")
-	if v, err := p.Get("foo"); err != nil {
-		t.Errorf("unexpected error: %s", err.Error())
-	} else if v != "bar" {
-		t.Errorf("expected bar string, got %s", v)
-	}
+	v, err = p.Get("foo")
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", v)
 
 	p.Set("foo", "bar2")
-	if v, err := p.Get("foo"); err != nil {
-		t.Errorf("unexpected error: %s", err.Error())
-	} else if v != "bar2" {
-		t.Errorf("expected bar2 string, got %s", v)
-	}
+	v, err = p.Get("foo")
+	assert.NoError(t, err)
+	assert.Equal(t, "bar2", v)
 }
 
 func TestSoapParamsEncode(t *testing.T) {
@@ -207,46 +185,35 @@ func TestSoapParamsEncode(t *testing.T) {
 	p.Set("bar", "bar bar")
 	p.Set("baz", "YmFyCg==")
 
-	fixt := "foo=bar%2Bbar&bar=bar+bar&baz=YmFyCg%3D%3D"
-	if enc := p.Encode(); enc != fixt {
-		t.Errorf("encoded params do not match\nexpected: %s\nactual:   %s\n", fixt, enc)
-	}
+	assert.Equal(t, "foo=bar%2Bbar&bar=bar+bar&baz=YmFyCg%3D%3D", p.Encode())
 }
 
 func TestGetSOAPArgs(t *testing.T) {
-	fixture := []byte("<ns1:getStuff>foo</ns1:getStuff>")
-	if o := getSOAPArgs("getStuff", "foo"); !bytes.Equal(o, fixture) {
-		t.Errorf("\nexpected: %s\nactual:   %s\n", fixture, o)
-	}
+	var fixture []byte
+
+	fixture = []byte("<ns1:getStuff>foo</ns1:getStuff>")
+	assert.Equal(t, fixture, getSOAPArgs("getStuff", "foo"))
 
 	fixture = []byte("<ns1:getStuff>foobar</ns1:getStuff>")
-	if o := getSOAPArgs("getStuff", "foo", "bar"); !bytes.Equal(o, fixture) {
-		t.Errorf("\nexpected: %s\nactual:   %s\n", fixture, o)
-	}
-
-	if o := getSOAPArgs("getStuff", []string{"foo", "bar"}...); !bytes.Equal(o, fixture) {
-		t.Errorf("\nexpected: %s\nactual:   %s\n", fixture, o)
-	}
+	assert.Equal(t, fixture, getSOAPArgs("getStuff", "foo", "bar"))
+	assert.Equal(t, fixture, getSOAPArgs("getStuff", []string{"foo", "bar"}...))
 }
 
 func TestGetSOAPArg(t *testing.T) {
 	tests := []struct {
-		testName string
-		name     string
-		input    interface{}
-		fixture  string
+		name    string
+		input   interface{}
+		fixture string
 	}{
-		{"string", "fooBar", "barFoo", `<fooBar xsi:type="xsd:string">barFoo</fooBar>`},
-		{"int", "BooFar", int(1), `<BooFar xsi:type="xsd:integer">1</BooFar>`},
-		{"int32", "BarFoo", int32(1), `<BarFoo xsi:type="xsd:integer">1</BarFoo>`},
-		{"int64", "BaoFor", int64(1), `<BaoFor xsi:type="xsd:integer">1</BaoFor>`},
-		{"array", "barFoo", []string{"bar", "Foo"}, `<barFoo SOAP-ENC:arrayType="xsd:string[2]" xsi:type="ns1:ArrayOfString"><item xsi:type="xsd:string">bar</item><item xsi:type="xsd:string">Foo</item></barFoo>`},
+		{"fooBar", "barFoo", `<fooBar xsi:type="xsd:string">barFoo</fooBar>`},
+		{"BooFar", int(1), `<BooFar xsi:type="xsd:integer">1</BooFar>`},
+		{"BarFoo", int32(1), `<BarFoo xsi:type="xsd:integer">1</BarFoo>`},
+		{"BaoFor", int64(1), `<BaoFor xsi:type="xsd:integer">1</BaoFor>`},
+		{"barFoo", []string{"bar", "Foo"}, `<barFoo SOAP-ENC:arrayType="xsd:string[2]" xsi:type="ns1:ArrayOfString"><item xsi:type="xsd:string">bar</item><item xsi:type="xsd:string">Foo</item></barFoo>`},
 	}
 
 	for _, test := range tests {
-		if output := getSOAPArg(test.name, test.input); output != test.fixture {
-			t.Errorf("getSOAPArg test '%s' failed\nexpected: %s\nactual:   %s\n", test.testName, test.fixture, output)
-		}
+		assert.Equal(t, test.fixture, getSOAPArg(test.name, test.input))
 	}
 }
 
@@ -260,11 +227,8 @@ func TestPadXMLData(t *testing.T) {
 		`<foo bar="baz">`,
 	}
 
-	output := string(padXMLData(data, padding))
 	fixture := `<foo><foo><foo bar="baz"><fooBar xsi:type="xsd:string">barFoo</fooBar></foo></foo></foo>`
-	if output != fixture {
-		t.Errorf("padding not same\nexpected: %s\nactual:   %s\n", fixture, output)
-	}
+	assert.Equal(t, fixture, string(padXMLData(data, padding)))
 }
 
 func TestSoapRequestAddArgument(t *testing.T) {

--- a/webhosting/webhosting.go
+++ b/webhosting/webhosting.go
@@ -47,12 +47,12 @@ type MailBox struct {
 // EncodeParams returns MailBox parameters ready to be used for constructing a signature
 func (m MailBox) EncodeParams(prm gotransip.ParamsContainer) {
 	idx := prm.Len()
-	prm.Set(fmt.Sprintf("%d[address]", idx), m.Address)
-	prm.Set(fmt.Sprintf("%d[spamCheckerStrength]", idx), string(m.SpamCheckerStrength))
-	prm.Set(fmt.Sprintf("%d[maxDiskUsage]", idx), fmt.Sprintf("%d", m.MaxDiskUsage))
-	prm.Set(fmt.Sprintf("%d[hasVacationReply]", idx), fmt.Sprintf("%t", m.HasVacationReply))
-	prm.Set(fmt.Sprintf("%d[vacationReplySubject]", idx), m.VacationReplySubject)
-	prm.Set(fmt.Sprintf("%d[vacationReplyMessage]", idx), m.VacationReplyMessage)
+	prm.Add(fmt.Sprintf("%d[address]", idx), m.Address)
+	prm.Add(fmt.Sprintf("%d[spamCheckerStrength]", idx), string(m.SpamCheckerStrength))
+	prm.Add(fmt.Sprintf("%d[maxDiskUsage]", idx), fmt.Sprintf("%d", m.MaxDiskUsage))
+	prm.Add(fmt.Sprintf("%d[hasVacationReply]", idx), fmt.Sprintf("%t", m.HasVacationReply))
+	prm.Add(fmt.Sprintf("%d[vacationReplySubject]", idx), m.VacationReplySubject)
+	prm.Add(fmt.Sprintf("%d[vacationReplyMessage]", idx), m.VacationReplyMessage)
 }
 
 // EncodeArgs returns MailBox XML body ready to be passed in the SOAP call
@@ -88,7 +88,7 @@ type SubDomain struct {
 // EncodeParams returns SubDomain parameters ready to be used for constructing a signature
 func (s SubDomain) EncodeParams(prm gotransip.ParamsContainer) {
 	idx := prm.Len()
-	prm.Set(fmt.Sprintf("%d[name]", idx), s.Name)
+	prm.Add(fmt.Sprintf("%d[name]", idx), s.Name)
 }
 
 // EncodeArgs returns SubDomain XML body ready to be passed in the SOAP call
@@ -121,8 +121,8 @@ type MailForward struct {
 // EncodeParams returns MailForward parameters ready to be used for constructing a signature
 func (m MailForward) EncodeParams(prm gotransip.ParamsContainer) {
 	idx := prm.Len()
-	prm.Set(fmt.Sprintf("%d[name]", idx), m.Name)
-	prm.Set(fmt.Sprintf("%d[targetAddress]", idx), m.TargetAddress)
+	prm.Add(fmt.Sprintf("%d[name]", idx), m.Name)
+	prm.Add(fmt.Sprintf("%d[targetAddress]", idx), m.TargetAddress)
 }
 
 // EncodeArgs returns MailForward XML body ready to be passed in the SOAP call
@@ -144,9 +144,9 @@ type Database struct {
 // EncodeParams returns Database parameters ready to be used for constructing a signature
 func (db Database) EncodeParams(prm gotransip.ParamsContainer) {
 	idx := prm.Len()
-	prm.Set(fmt.Sprintf("%d[name]", idx), db.Name)
-	prm.Set(fmt.Sprintf("%d[username]", idx), db.Username)
-	prm.Set(fmt.Sprintf("%d[maxDiskUsage]", idx), fmt.Sprintf("%d", db.MaxDiskUsage))
+	prm.Add(fmt.Sprintf("%d[name]", idx), db.Name)
+	prm.Add(fmt.Sprintf("%d[username]", idx), db.Username)
+	prm.Add(fmt.Sprintf("%d[maxDiskUsage]", idx), fmt.Sprintf("%d", db.MaxDiskUsage))
 }
 
 // EncodeArgs returns Database XML body ready to be passed in the SOAP call
@@ -174,14 +174,14 @@ type CronJob struct {
 // EncodeParams returns CronJob parameters ready to be used for constructing a signature
 func (c CronJob) EncodeParams(prm gotransip.ParamsContainer) {
 	idx := prm.Len()
-	prm.Set(fmt.Sprintf("%d[name]", idx), c.Name)
-	prm.Set(fmt.Sprintf("%d[url]", idx), c.URL)
-	prm.Set(fmt.Sprintf("%d[email]", idx), c.Email)
-	prm.Set(fmt.Sprintf("%d[minuteTrigger]", idx), c.MinuteTrigger)
-	prm.Set(fmt.Sprintf("%d[hourTrigger]", idx), c.HourTrigger)
-	prm.Set(fmt.Sprintf("%d[dayTrigger]", idx), c.DayTrigger)
-	prm.Set(fmt.Sprintf("%d[monthTrigger]", idx), c.MonthTrigger)
-	prm.Set(fmt.Sprintf("%d[weekdayTrigger]", idx), c.WeekdayTrigger)
+	prm.Add(fmt.Sprintf("%d[name]", idx), c.Name)
+	prm.Add(fmt.Sprintf("%d[url]", idx), c.URL)
+	prm.Add(fmt.Sprintf("%d[email]", idx), c.Email)
+	prm.Add(fmt.Sprintf("%d[minuteTrigger]", idx), c.MinuteTrigger)
+	prm.Add(fmt.Sprintf("%d[hourTrigger]", idx), c.HourTrigger)
+	prm.Add(fmt.Sprintf("%d[dayTrigger]", idx), c.DayTrigger)
+	prm.Add(fmt.Sprintf("%d[monthTrigger]", idx), c.MonthTrigger)
+	prm.Add(fmt.Sprintf("%d[weekdayTrigger]", idx), c.WeekdayTrigger)
 }
 
 // EncodeArgs returns CronJob XML body ready to be passed in the SOAP call


### PR DESCRIPTION
### Short description
To fix https://github.com/transip/gotransip/issues/7, I've refactored the way `soapParams` is built up and later encoded. This was unnecessarily complicated and lacked proper support for other types than strings. Since I removed the possibility to update fields set earlier, I've renamed `soapParams.Set` to to `soapParams.Add` since it only made sense. This explains the many changes throughout the code.

### Checklist
<!-- Please check the boxes of the steps you took before making this PR -->
- [x] I read the [CONTRIBUTING.md](https://github.com/transip/gotransip/blob/master/CONTRIBUTING.md) document
- [x] This code actually compiles
- [x] This code solves my problem
- [x] I've updated the inline documentation
- [x] I added or modified test(s) to prevent this issue from ever occuring again

<!-- If your code doesn't make `go vet` or `go fmt` happy, Travis CI will complain and we can't merge your PR no matter how good it is. -->
