### PR TITLE
added a basic go.mod so the go toolchain works outside $GOPATH

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/transip/gotransip
+
+require github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=


### PR DESCRIPTION
### Short description
Added a basic go.mod so the go toolchain works outside $GOPATH. It doesn't matter much as the library doesn't have any runtime dependencies, but it is still nice to be able to work outside $GOPATH in go >= 1.11

### Checklist
<!-- Please check the boxes of the steps you took before making this PR -->
(https://github.com/transip/gotransip/blob/master/CONTRIBUTING.md) document
- [x] This code actually compiles
- [x] This code solves my problem
- [x] I've updated the inline documentation
- [x] I added or modified test(s) to prevent this issue from ever occuring again

<!-- If your code doesn't make `go vet` or `go fmt` happy, Travis CI will complain and we can't merge your PR no matter how good it is. -->
