### PR TITLE
"v2+" module name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: go
 
 go:
-  - "1.10"
+  - "1.11"
+  - "1.x"
+
+env:
+  global:
+    - GO111MODULE=on
 
 before_install:
-  - go get -u golang.org/x/lint/golint
+  - GO111MODULE=off go get -u golang.org/x/lint/golint
   - echo $PATH
   - find $GOPATH/bin
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.11"
+  - "1.12"
   - "1.x"
 
 env:

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ package main
 import (
   "fmt"
 
-  "github.com/transip/gotransip"
-  "github.com/transip/gotransip/vps"
+  "github.com/transip/gotransip/v5"
+  "github.com/transip/gotransip/v5/vps"
 )
 
 func main() {

--- a/colo/api.go
+++ b/colo/api.go
@@ -3,7 +3,7 @@ package colo
 import (
 	"net"
 
-	"github.com/transip/gotransip"
+	"github.com/transip/gotransip/v5"
 )
 
 // This file holds all ColocationService methods directly ported from TransIP API

--- a/colo/api_test.go
+++ b/colo/api_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/transip/gotransip"
+	"github.com/transip/gotransip/v5"
 )
 
 func TestGetColoNames(t *testing.T) {

--- a/domain/api.go
+++ b/domain/api.go
@@ -1,7 +1,7 @@
 package domain
 
 import (
-	"github.com/transip/gotransip"
+	"github.com/transip/gotransip/v5"
 )
 
 // This file holds all DomainService methods directly ported from TransIP API

--- a/domain/api_test.go
+++ b/domain/api_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/transip/gotransip"
+	"github.com/transip/gotransip/v5"
 )
 
 func TestBatchCheckAvailability(t *testing.T) {

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/transip/gotransip"
-	"github.com/transip/gotransip/util"
+	"github.com/transip/gotransip/v5"
+	"github.com/transip/gotransip/v5/util"
 )
 
 const (

--- a/domain/domain_test.go
+++ b/domain/domain_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/transip/gotransip"
+	"github.com/transip/gotransip/v5"
 )
 
 func getFixture(filename string) (string, error) {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/transip/gotransip/v5
 
-go 1.11
+go 1.12
 
 require github.com/stretchr/testify v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
-module github.com/transip/gotransip
+module github.com/transip/gotransip/v5
+
+go 1.11
 
 require github.com/stretchr/testify v1.3.0

--- a/haip/api.go
+++ b/haip/api.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/transip/gotransip"
-	"github.com/transip/gotransip/util"
+	"github.com/transip/gotransip/v5"
+	"github.com/transip/gotransip/v5/util"
 )
 
 // This file holds all HaipService methods directly ported from TransIP API

--- a/haip/api_test.go
+++ b/haip/api_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/transip/gotransip"
+	"github.com/transip/gotransip/v5"
 )
 
 func TestGetCertificatesByHaip(t *testing.T) {

--- a/haip/haip.go
+++ b/haip/haip.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/transip/gotransip/util"
-	"github.com/transip/gotransip/vps"
+	"github.com/transip/gotransip/v5/util"
+	"github.com/transip/gotransip/v5/vps"
 )
 
 const (

--- a/vps/api.go
+++ b/vps/api.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/transip/gotransip"
-	"github.com/transip/gotransip/util"
+	"github.com/transip/gotransip/v5"
+	"github.com/transip/gotransip/v5/util"
 )
 
 // This file holds all VpsService methods directly ported from TransIP API

--- a/vps/api_test.go
+++ b/vps/api_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/transip/gotransip"
+	"github.com/transip/gotransip/v5"
 )
 
 func TestGetActiveAddonsForVps(t *testing.T) {

--- a/vps/vps.go
+++ b/vps/vps.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/transip/gotransip/util"
+	"github.com/transip/gotransip/v5/util"
 )
 
 const (

--- a/webhosting/api.go
+++ b/webhosting/api.go
@@ -1,6 +1,6 @@
 package webhosting
 
-import "github.com/transip/gotransip"
+import "github.com/transip/gotransip/v5"
 
 // This file holds all WebhostingService methods directly ported from TransIP API
 

--- a/webhosting/api_test.go
+++ b/webhosting/api_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/transip/gotransip"
+	"github.com/transip/gotransip/v5"
 )
 
 func TestGetAvailablePackages(t *testing.T) {

--- a/webhosting/webhosting.go
+++ b/webhosting/webhosting.go
@@ -3,7 +3,7 @@ package webhosting
 import (
 	"fmt"
 
-	"github.com/transip/gotransip"
+	"github.com/transip/gotransip/v5"
 )
 
 const (

--- a/webhosting/webhosting_test.go
+++ b/webhosting/webhosting_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/transip/gotransip"
+	"github.com/transip/gotransip/v5"
 )
 
 func TestMailBoxEncoding(t *testing.T) {


### PR DESCRIPTION
### Short description

for the `v2+` version, the go modules need that the module path to sync with the major version.

https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher

https://proxy.golang.org/github.com/transip/gotransip/@v/v5.15.0.info
```
not found: github.com/transip/gotransip@v5.15.0: invalid version: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v5
```


### Checklist
<!-- Please check the boxes of the steps you took before making this PR -->
- [x] I read the [CONTRIBUTING.md](https://github.com/transip/gotransip/blob/master/CONTRIBUTING.md) document
- [x] This code actually compiles
- [x] This code solves my problem
- [x] I've updated the inline documentation
- [ ] I added or modified test(s) to prevent this issue from ever occurring again

<!-- If your code doesn't make `go vet` or `go fmt` happy, Travis CI will complain and we can't merge your PR no matter how good it is. -->
