### PR TITLE
added DNSEntryTypes for SSHFP, TLSA and CAA-records

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -190,6 +190,12 @@ var (
 	DNSEntryTypeTXT DNSEntryType = "TXT"
 	// DNSEntryTypeSRV represents an SRV-record
 	DNSEntryTypeSRV DNSEntryType = "SRV"
+	// DNSEntryTypeSSHFP represents an SSHFP-record
+	DNSEntryTypeSSHFP DNSEntryType = "SSHFP"
+	// DNSEntryTypeTLSA represents a TLSA-record
+	DNSEntryTypeTLSA DNSEntryType = "TLSA"
+	// DNSEntryTypeCAA represents a CAA-record
+	DNSEntryTypeCAA DNSEntryType = "CAA"
 )
 
 // DNSEntry represents a Transip_DnsEntry object as described at


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the possible issue # it's fixing -->
Added DNSEntry types for `SSHFP`, `TLSA` and `CAA` DNS records, to fully implement API version 5.16

### Checklist
<!-- Please check the boxes of the steps you took before making this PR -->
- [x] I read the [CONTRIBUTING.md](https://github.com/transip/gotransip/blob/master/CONTRIBUTING.md) document
- [x] This code actually compiles
- [ ] This code solves my problem
- [x] I've updated the inline documentation
- [ ] I added or modified test(s) to prevent this issue from ever occuring again

<!-- If your code doesn't make `go vet` or `go fmt` happy, Travis CI will complain and we can't merge your PR no matter how good it is. -->
