### PR TITLE
implemented functions to get default DNS entry sets

### DIFF
--- a/domain/api.go
+++ b/domain/api.go
@@ -416,3 +416,65 @@ func RemoveAllDNSSecEntries(c gotransip.Client, domainName string) error {
 
 	return c.Call(sr, nil)
 }
+
+// GetDefaultDNSEntries returns a list of the default DNS Entries for the
+// currently authenticated API user
+func GetDefaultDNSEntries(c gotransip.Client) (DNSEntries, error) {
+	sr := gotransip.SoapRequest{
+		Service: serviceName,
+		Method:  "getDefaultDnsEntries",
+	}
+
+	var v struct {
+		V DNSEntries `xml:"item"`
+	}
+	err := c.Call(sr, &v)
+	return v.V, err
+}
+
+// GetDefaultDNSEntriesByDomainName returns a list of the default DNS Entries for
+// the given domain name
+func GetDefaultDNSEntriesByDomainName(c gotransip.Client, domainName string) (DNSEntries, error) {
+	sr := gotransip.SoapRequest{
+		Service: serviceName,
+		Method:  "getDefaultDnsEntriesByDomainName",
+	}
+	sr.AddArgument("domainName", domainName)
+
+	var v struct {
+		V DNSEntries `xml:"item"`
+	}
+	err := c.Call(sr, &v)
+	return v.V, err
+}
+
+// GetDefaultNameservers returns a list of the default list of nameservers for
+// the currently authenticated API User
+func GetDefaultNameservers(c gotransip.Client) (Nameservers, error) {
+	sr := gotransip.SoapRequest{
+		Service: serviceName,
+		Method:  "getDefaultNameservers",
+	}
+
+	var v struct {
+		V Nameservers `xml:"item"`
+	}
+	err := c.Call(sr, &v)
+	return v.V, err
+}
+
+// GetDefaultNameserversByDomainName returns a list of the default list of
+// nameservers for the given domain name
+func GetDefaultNameserversByDomainName(c gotransip.Client, domainName string) (Nameservers, error) {
+	sr := gotransip.SoapRequest{
+		Service: serviceName,
+		Method:  "getDefaultNameserversByDomainName",
+	}
+	sr.AddArgument("domainName", domainName)
+
+	var v struct {
+		V Nameservers `xml:"item"`
+	}
+	err := c.Call(sr, &v)
+	return v.V, err
+}

--- a/domain/api_test.go
+++ b/domain/api_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/transip/gotransip"
 )
 
@@ -284,4 +285,72 @@ func TestGetDNSSecEntries(t *testing.T) {
 	assert.Equal(t, DNSSecFlagZSK, dns[1].Flags)
 	assert.Equal(t, DNSSecAlgorithmECDSAP384SHA384, dns[1].Algorithm)
 	assert.Equal(t, "dWl4YWl4MHBoZWVtN3lhcGhhaWIwYWhsYWVqMW9odzB1YThYaTFoYUJhaHBvOWhhZXNhaDJBaGQ4b2s4VGhvU2hhaWozc2hhaDluYWljYWljN2lvaG83aW9YZWRvb2w0YWhXYWl0bzNYZWlQaGFlNWVpZ2VpcGVlZzdhZXhpZTAK", dns[1].PublicKey)
+}
+
+func TestGetDefaultDNSEntries(t *testing.T) {
+	var err error
+	c := gotransip.FakeSOAPClient{}
+	err = c.FixtureFromFile("testdata/getdefaultdnsentries.xml")
+	assert.NoError(t, err)
+
+	entries, err := GetDefaultDNSEntries(c)
+	require.NoError(t, err)
+	assert.IsType(t, DNSEntries{}, entries)
+	assert.Equal(t, 2, len(entries))
+	assert.Equal(t, "1.2.3.4", entries[0].Content)
+	assert.Equal(t, int64(86400), entries[0].TTL)
+	assert.Equal(t, "@", entries[0].Name)
+	assert.Equal(t, DNSEntryTypeA, entries[0].Type)
+	assert.Equal(t, "fe80::1", entries[1].Content)
+}
+
+func TestGetDefaultDNSEntriesByDomainName(t *testing.T) {
+	var err error
+	c := gotransip.FakeSOAPClient{}
+	err = c.FixtureFromFile("testdata/getdefaultdnsentriesbydomainname.xml")
+	assert.NoError(t, err)
+
+	entries, err := GetDefaultDNSEntriesByDomainName(c, "example.org")
+	require.NoError(t, err)
+	assert.IsType(t, DNSEntries{}, entries)
+	assert.Equal(t, 2, len(entries))
+	assert.Equal(t, "1.2.3.4", entries[0].Content)
+	assert.Equal(t, int64(86400), entries[0].TTL)
+	assert.Equal(t, "@", entries[0].Name)
+	assert.Equal(t, DNSEntryTypeA, entries[0].Type)
+	assert.Equal(t, "fe80::1", entries[1].Content)
+}
+
+func TestGetDefaultNameservers(t *testing.T) {
+	var err error
+	c := gotransip.FakeSOAPClient{}
+	err = c.FixtureFromFile("testdata/getdefaultnameservers.xml")
+	assert.NoError(t, err)
+
+	ns, err := GetDefaultNameservers(c)
+	require.NoError(t, err)
+	assert.IsType(t, Nameservers{}, ns)
+	assert.Equal(t, 3, len(ns))
+	assert.Equal(t, "ns0.transip.net", ns[0].Hostname)
+	assert.Equal(t, net.ParseIP("195.135.195.195"), ns[0].IPv4Address)
+	assert.Equal(t, net.ParseIP("2a01:7c8:dddd:195::195"), ns[0].IPv6Address)
+	assert.Equal(t, "ns1.transip.nl", ns[1].Hostname)
+	assert.Equal(t, "ns2.transip.eu", ns[2].Hostname)
+}
+
+func TestGetDefaultNameserversByDomainName(t *testing.T) {
+	var err error
+	c := gotransip.FakeSOAPClient{}
+	err = c.FixtureFromFile("testdata/getdefaultnameserversbydomainname.xml")
+	assert.NoError(t, err)
+
+	ns, err := GetDefaultNameserversByDomainName(c, "example.org")
+	require.NoError(t, err)
+	assert.IsType(t, Nameservers{}, ns)
+	assert.Equal(t, 3, len(ns))
+	assert.Equal(t, "ns0.transip.net", ns[0].Hostname)
+	assert.Equal(t, net.ParseIP("195.135.195.195"), ns[0].IPv4Address)
+	assert.Equal(t, net.ParseIP("2a01:7c8:dddd:195::195"), ns[0].IPv6Address)
+	assert.Equal(t, "ns1.transip.nl", ns[1].Hostname)
+	assert.Equal(t, "ns2.transip.eu", ns[2].Hostname)
 }

--- a/domain/testdata/getdefaultdnsentries.xml
+++ b/domain/testdata/getdefaultdnsentries.xml
@@ -1,0 +1,25 @@
+<SOAP-ENV:Envelope
+  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+  xmlns:ns1="http://www.transip.nl/soap"
+  xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+  <SOAP-ENV:Body>
+    <ns1:getDefaultDnsEntriesResponse>
+      <return SOAP-ENC:arrayType="ns1:DnsEntry[2]" xsi:type="ns1:ArrayOfDnsEntry">
+        <item xsi:type="ns1:DnsEntry">
+          <name xsi:type="xsd:string">@</name>
+          <expire xsi:type="xsd:int">86400</expire>
+          <type xsi:type="xsd:string">A</type>
+          <content xsi:type="xsd:string">1.2.3.4</content>
+        </item>
+        <item xsi:type="ns1:DnsEntry">
+          <name xsi:type="xsd:string">@</name>
+          <expire xsi:type="xsd:int">86400</expire>
+          <type xsi:type="xsd:string">AAAA</type>
+          <content xsi:type="xsd:string">fe80::1</content>
+        </item>
+      </return>
+    </ns1:getDefaultDnsEntriesResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/domain/testdata/getdefaultdnsentriesbydomainname.xml
+++ b/domain/testdata/getdefaultdnsentriesbydomainname.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope
+  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+  xmlns:ns1="http://www.transip.nl/soap"
+  xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+  <SOAP-ENV:Body>
+    <ns1:getDefaultDnsEntriesByDomainNameResponse>
+      <return SOAP-ENC:arrayType="ns1:DnsEntry[2]" xsi:type="ns1:ArrayOfDnsEntry">
+        <item xsi:type="ns1:DnsEntry">
+          <name xsi:type="xsd:string">@</name>
+          <expire xsi:type="xsd:int">86400</expire>
+          <type xsi:type="xsd:string">A</type>
+          <content xsi:type="xsd:string">1.2.3.4</content>
+        </item>
+        <item xsi:type="ns1:DnsEntry">
+          <name xsi:type="xsd:string">@</name>
+          <expire xsi:type="xsd:int">86400</expire>
+          <type xsi:type="xsd:string">AAAA</type>
+          <content xsi:type="xsd:string">fe80::1</content>
+        </item>
+      </return>
+    </ns1:getDefaultDnsEntriesByDomainNameResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/domain/testdata/getdefaultnameservers.xml
+++ b/domain/testdata/getdefaultnameservers.xml
@@ -1,0 +1,29 @@
+<SOAP-ENV:Envelope
+  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+  xmlns:ns1="http://www.transip.nl/soap"
+  xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+  <SOAP-ENV:Body>
+    <ns1:getDefaultNameserversResponse>
+      <return SOAP-ENC:arrayType="ns1:Nameserver[3]" xsi:type="ns1:ArrayOfNameserver">
+        <item xsi:type="ns1:Nameserver">
+          <hostname xsi:type="xsd:string">ns0.transip.net</hostname>
+          <ipv4 xsi:type="xsd:string">195.135.195.195</ipv4>
+          <ipv6 xsi:type="xsd:string">2a01:7c8:dddd:195::195</ipv6>
+        </item>
+        <item xsi:type="ns1:Nameserver">
+          <hostname xsi:type="xsd:string">ns1.transip.nl</hostname>
+          <ipv4 xsi:type="xsd:string">195.8.195.195</ipv4>
+          <ipv6 xsi:type="xsd:string">a01:7c8:7000:195::195</ipv6>
+        </item>
+        <item xsi:type="ns1:Nameserver">
+          <hostname xsi:type="xsd:string">ns2.transip.eu</hostname>
+          <ipv4 xsi:type="xsd:string">37.97.199.195</ipv4>
+          <ipv6 xsi:type="xsd:string">2a01:7c8:f:c1f::195</ipv6>
+        </item>
+      </return>
+    </ns1:getDefaultNameserversResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/domain/testdata/getdefaultnameserversbydomainname.xml
+++ b/domain/testdata/getdefaultnameserversbydomainname.xml
@@ -1,0 +1,29 @@
+<SOAP-ENV:Envelope
+  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+  xmlns:ns1="http://www.transip.nl/soap"
+  xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+  <SOAP-ENV:Body>
+    <ns1:getDefaultNameserversByDomainNameResponse>
+      <return SOAP-ENC:arrayType="ns1:Nameserver[3]" xsi:type="ns1:ArrayOfNameserver">
+        <item xsi:type="ns1:Nameserver">
+          <hostname xsi:type="xsd:string">ns0.transip.net</hostname>
+          <ipv4 xsi:type="xsd:string">195.135.195.195</ipv4>
+          <ipv6 xsi:type="xsd:string">2a01:7c8:dddd:195::195</ipv6>
+        </item>
+        <item xsi:type="ns1:Nameserver">
+          <hostname xsi:type="xsd:string">ns1.transip.nl</hostname>
+          <ipv4 xsi:type="xsd:string">195.8.195.195</ipv4>
+          <ipv6 xsi:type="xsd:string">a01:7c8:7000:195::195</ipv6>
+        </item>
+        <item xsi:type="ns1:Nameserver">
+          <hostname xsi:type="xsd:string">ns2.transip.eu</hostname>
+          <ipv4 xsi:type="xsd:string">37.97.199.195</ipv4>
+          <ipv6 xsi:type="xsd:string">2a01:7c8:f:c1f::195</ipv6>
+        </item>
+      </return>
+    </ns1:getDefaultNameserversByDomainNameResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>


### PR DESCRIPTION
### Short description
Implemented `GetDefaultDNSEntries`, `GetDefaultDNSEntriesByDomainName`, `GetDefaultNameservers` and `GetDefaultNameserversByDomainName` to update to API version 5.17

### Checklist
<!-- Please check the boxes of the steps you took before making this PR -->
- [x] I read the [CONTRIBUTING.md](https://github.com/transip/gotransip/blob/master/CONTRIBUTING.md) document
- [x] This code actually compiles
- [ ] This code solves my problem
- [x] I've updated the inline documentation
- [x] I added or modified test(s) to prevent this issue from ever occuring again

<!-- If your code doesn't make `go vet` or `go fmt` happy, Travis CI will complain and we can't merge your PR no matter how good it is. -->
