### PR TITLE
Use Url.Values for getting vps usage data

### DIFF
--- a/authenticator/filetokencache_test.go
+++ b/authenticator/filetokencache_test.go
@@ -5,11 +5,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/transip/gotransip/v6/jwt"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
 func TestFileTokenCache_New(t *testing.T) {
-	tmpFile := os.TempDir() + "/gotransip_test123"
+	tmpFile := filepath.Join(os.TempDir(), "gotransip_test123")
 	defer os.Remove(tmpFile)
 
 	_, err := NewFileTokenCache(tmpFile)
@@ -17,7 +18,7 @@ func TestFileTokenCache_New(t *testing.T) {
 }
 
 func TestFileTokenCache_Set(t *testing.T) {
-	tmpFile := os.TempDir() + "/gotransip_test123"
+	tmpFile := filepath.Join(os.TempDir(), "gotransip_test123")
 	defer os.Remove(tmpFile)
 
 	cache, err := NewFileTokenCache(tmpFile)

--- a/authenticator/filetokencache_test.go
+++ b/authenticator/filetokencache_test.go
@@ -9,16 +9,18 @@ import (
 )
 
 func TestFileTokenCache_New(t *testing.T) {
-	defer os.Remove("/tmp/gotransip_test123")
+	tmpFile := os.TempDir() + "/gotransip_test123"
+	defer os.Remove(tmpFile)
 
-	_, err := NewFileTokenCache("/tmp/gotransip_test123")
+	_, err := NewFileTokenCache(tmpFile)
 	require.NoError(t, err)
 }
 
 func TestFileTokenCache_Set(t *testing.T) {
-	defer os.Remove("/tmp/gotransip_test123")
+	tmpFile := os.TempDir() + "/gotransip_test123"
+	defer os.Remove(tmpFile)
 
-	cache, err := NewFileTokenCache("/tmp/gotransip_test123")
+	cache, err := NewFileTokenCache(tmpFile)
 	require.NoError(t, err)
 
 	tokenToCache := jwt.Token{ExpiryDate: 2118745550, RawToken: DemoToken}
@@ -31,9 +33,10 @@ func TestFileTokenCache_Set(t *testing.T) {
 }
 
 func TestFileTokenCache_SetGetFromFile(t *testing.T) {
-	defer os.Remove("/tmp/gotransip_cache_setgetfromfile")
+	cacheLocation := os.TempDir() + "/gotransip_cache_setgetfromfile"
+	defer os.Remove(cacheLocation)
 
-	cache, err := NewFileTokenCache("/tmp/gotransip_cache_setgetfromfile")
+	cache, err := NewFileTokenCache(cacheLocation)
 	require.NoError(t, err)
 
 	tokenToCache := jwt.Token{RawToken: DemoToken + DemoToken}
@@ -49,7 +52,7 @@ func TestFileTokenCache_SetGetFromFile(t *testing.T) {
 	err = cache.File.Close()
 	require.NoError(t, err)
 
-	cache, err = NewFileTokenCache("/tmp/gotransip_cache_setgetfromfile")
+	cache, err = NewFileTokenCache(cacheLocation)
 	require.NoError(t, err)
 
 	dataFromCache, err := cache.Get("testkey")

--- a/client_test.go
+++ b/client_test.go
@@ -77,8 +77,9 @@ func TestNewClient(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test that a tokencache is passed to the authenticator
-	defer os.Remove("/tmp/gotransip_test_token_cache")
-	cache, err := authenticator.NewFileTokenCache("/tmp/gotransip_test_token_cache")
+	cacheFile := os.TempDir() + "/gotransip_test_token_cache"
+	defer os.Remove(cacheFile)
+	cache, err := authenticator.NewFileTokenCache(cacheFile)
 	require.NoError(t, err)
 	client, err = newClient(ClientConfiguration{PrivateKeyPath: "testdata/signature.key", AccountName: "example-user", TokenCache: cache})
 	require.NoError(t, err)

--- a/client_test.go
+++ b/client_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path/filepath"
 	"testing"
 	"testing/iotest"
 	"time"
@@ -77,7 +78,7 @@ func TestNewClient(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test that a tokencache is passed to the authenticator
-	cacheFile := os.TempDir() + "/gotransip_test_token_cache"
+	cacheFile := filepath.Join(os.TempDir(), "gotransip_test_token_cache")
 	defer os.Remove(cacheFile)
 	cache, err := authenticator.NewFileTokenCache(cacheFile)
 	require.NoError(t, err)

--- a/vps/bigstorage.go
+++ b/vps/bigstorage.go
@@ -181,7 +181,11 @@ func (r *BigStorageRepository) RevertBackup(bigStorageName string, backupID int6
 // GetUsage allows you to query your bigstorage usage within a certain period
 func (r *BigStorageRepository) GetUsage(bigStorageName string, period UsagePeriod) ([]UsageDataDisk, error) {
 	var response usageDataDiskWrapper
-	restRequest := rest.Request{Endpoint: fmt.Sprintf("/big-storages/%s/usage", bigStorageName), Body: &period}
+	parameters := url.Values{
+		"dateTimeStart": []string{fmt.Sprintf("%d", period.TimeStart)},
+		"dateTimeEnd":   []string{fmt.Sprintf("%d", period.TimeEnd)},
+	}
+	restRequest := rest.Request{Endpoint: fmt.Sprintf("/big-storages/%s/usage", bigStorageName), Parameters: parameters}
 
 	err := r.Client.Get(restRequest, &response)
 
@@ -191,7 +195,7 @@ func (r *BigStorageRepository) GetUsage(bigStorageName string, period UsagePerio
 // GetUsageLast24Hours allows you to get usage statistics for a given bigstorage within the last 24 hours
 func (r *BigStorageRepository) GetUsageLast24Hours(bigStorageName string) ([]UsageDataDisk, error) {
 	// always define a period body, this way we don't have to depend on the empty body logic on the api server
-	period := UsagePeriod{TimeStart: time.Now().Unix() - 24*3600, TimeEnd: time.Now().Unix()}
+	period := UsagePeriod{TimeStart: time.Now().Add(-24 * time.Hour).Unix(), TimeEnd: time.Now().Unix()}
 
 	return r.GetUsage(bigStorageName, period)
 }

--- a/vps/repository.go
+++ b/vps/repository.go
@@ -164,8 +164,14 @@ func (r *Repository) GetUsage(vpsName string, usageTypes []UsageType, period Usa
 	for _, usageType := range usageTypes {
 		types = append(types, string(usageType))
 	}
-	requestBody := vpsUsageRequest{Types: strings.Join(types, ","), UsagePeriod: period}
-	restRequest := rest.Request{Endpoint: fmt.Sprintf("/vps/%s/usage", vpsName), Body: &requestBody}
+
+	parameters := url.Values{
+		"dateTimeStart": []string{fmt.Sprintf("%d", period.TimeStart)},
+		"dateTimeEnd":   []string{fmt.Sprintf("%d", period.TimeEnd)},
+		"types":         []string{strings.Join(types, ",")},
+	}
+
+	restRequest := rest.Request{Endpoint: fmt.Sprintf("/vps/%s/usage", vpsName), Parameters: parameters}
 	err := r.Client.Get(restRequest, &response)
 
 	return response.Usage, err
@@ -184,7 +190,7 @@ func (r *Repository) GetAllUsage(vpsName string, period UsagePeriod) (Usage, err
 // GetAllUsage24Hours returns all usage data for a given Vps within the last 24 hours
 func (r *Repository) GetAllUsage24Hours(vpsName string) (Usage, error) {
 	// always define a period body, this way we don't have to depend on the empty body logic on the api server
-	period := UsagePeriod{TimeStart: time.Now().Unix() - 24*3600, TimeEnd: time.Now().Unix()}
+	period := UsagePeriod{TimeStart: time.Now().Add(-24 * time.Hour).Unix(), TimeEnd: time.Now().Unix()}
 
 	return r.GetAllUsage(vpsName, period)
 }

--- a/vps/repository_test.go
+++ b/vps/repository_test.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -345,8 +346,15 @@ func TestRepository_Cancel(t *testing.T) {
 
 func TestRepository_GetUsageData(t *testing.T) {
 	const apiResponse = `{"usage":{"cpu":[{"percentage":3.11,"date":1574783109}]}} `
-	const expectedRequest = `{"types":"cpu","dateTimeStart":1500538995,"dateTimeEnd":1500542619}`
-	server := mockServer{t: t, expectedURL: "/vps/example-vps/usage", expectedMethod: "GET", statusCode: 200, expectedRequest: expectedRequest, response: apiResponse}
+
+	values := url.Values{
+		"dateTimeStart": []string{"1500538995"},
+		"dateTimeEnd":   []string{"1500542619"},
+		"types":         []string{"cpu"},
+	}
+
+	expectedUrl := "/vps/example-vps/usage?" + values.Encode()
+	server := mockServer{t: t, expectedURL: expectedUrl, expectedMethod: "GET", statusCode: 200, response: apiResponse}
 	client, tearDown := server.getClient()
 	defer tearDown()
 	repo := Repository{Client: *client}
@@ -361,8 +369,15 @@ func TestRepository_GetUsageData(t *testing.T) {
 
 func TestRepository_GetAllUsageDataByVps(t *testing.T) {
 	const apiResponse = `{ "usage": { "cpu": [ { "percentage": 3.11, "date": 1574783109 } ], "disk": [ { "iopsRead": 0.27, "iopsWrite": 0.13, "date": 1574783109 } ], "network": [ { "mbitOut": 100.2, "mbitIn": 249.93, "date": 1574783109 } ] } } `
-	const expectedRequest = `{"types":"cpu,disk,network","dateTimeStart":1500538995,"dateTimeEnd":1500542619}`
-	server := mockServer{t: t, expectedURL: "/vps/example-vps/usage", expectedMethod: "GET", statusCode: 200, expectedRequest: expectedRequest, response: apiResponse}
+
+	values := url.Values{
+		"dateTimeStart": []string{"1500538995"},
+		"dateTimeEnd":   []string{"1500542619"},
+		"types":         []string{"cpu,disk,network"},
+	}
+
+	expectedUrl := "/vps/example-vps/usage?" + values.Encode()
+	server := mockServer{t: t, expectedURL: expectedUrl, expectedMethod: "GET", statusCode: 200, response: apiResponse}
 	client, tearDown := server.getClient()
 	defer tearDown()
 	repo := Repository{Client: *client}
@@ -388,8 +403,15 @@ func TestRepository_GetAllUsageDataByVps(t *testing.T) {
 
 func TestRepository_GetAllUsageDataByVps24Hours(t *testing.T) {
 	const apiResponse = `{ "usage": { "cpu": [ { "percentage": 3.11, "date": 1574783109 } ], "disk": [ { "iopsRead": 0.27, "iopsWrite": 0.13, "date": 1574783109 } ], "network": [ { "mbitOut": 100.2, "mbitIn": 249.93, "date": 1574783109 } ] } } `
-	expectedRequest := fmt.Sprintf(`{"types":"cpu,disk,network","dateTimeStart":%d,"dateTimeEnd":%d}`, time.Now().Unix()-24*3600, time.Now().Unix())
-	server := mockServer{t: t, expectedURL: "/vps/example-vps/usage", expectedMethod: "GET", statusCode: 200, expectedRequest: expectedRequest, response: apiResponse}
+
+	values := url.Values{
+		"dateTimeStart": []string{fmt.Sprintf("%d", time.Now().Add(-24*time.Hour).Unix())},
+		"dateTimeEnd":   []string{fmt.Sprintf("%d", time.Now().Unix())},
+		"types":         []string{"cpu,disk,network"},
+	}
+
+	expectedUrl := "/vps/example-vps/usage?" + values.Encode()
+	server := mockServer{t: t, expectedURL: expectedUrl, expectedMethod: "GET", statusCode: 200, response: apiResponse}
 	client, tearDown := server.getClient()
 	defer tearDown()
 	repo := Repository{Client: *client}

--- a/vps/vps.go
+++ b/vps/vps.go
@@ -363,12 +363,6 @@ type UsageDataNetwork struct {
 	MbitOut float32 `json:"mbitOut"`
 }
 
-// vpsUsageRequest is used to marshall a usage request struct
-type vpsUsageRequest struct {
-	Types string `json:"types,omitempty"`
-	UsagePeriod
-}
-
 // UsagePeriod is struct that can be used to query usage statistics for a certain period
 type UsagePeriod struct {
 	// TimeStart contains a unix timestamp for the start of the period


### PR DESCRIPTION
This is needed because it is a GET request which means we can't set a
json-encoded body.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the possible issue # it's fixing -->

### Checklist
<!-- Please check the boxes of the steps you took before making this PR -->
- [x] I read the [CONTRIBUTING.md](https://github.com/transip/gotransip/blob/master/CONTRIBUTING.md) document
- [x] This code actually compiles
- [x] This code solves my problem
- [x] I've updated the inline documentation
- [x] I added or modified test(s) to prevent this issue from ever occuring again

<!-- If your code doesn't make `go vet` or `go fmt` happy, Travis CI will complain and we can't merge your PR no matter how good it is. -->
