### PR TITLE
Simplify signWithKey

### DIFF
--- a/authenticator/sign.go
+++ b/authenticator/sign.go
@@ -13,25 +13,11 @@ import (
 )
 
 var (
-	asn1Header = []byte{
-		0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03,
-		0x04, 0x02, 0x03, 0x05, 0x00, 0x04, 0x40,
-	}
 	// ErrDecodingPrivateKey will be thrown when an invalid private key has been given
 	ErrDecodingPrivateKey = errors.New("could not decode private key")
 )
 
 func signWithKey(body []byte, key []byte) (string, error) {
-	// create SHA512 hash of given parameters
-	h := sha512.New()
-	_, err := h.Write(body)
-	if err != nil {
-		return "", fmt.Errorf("signing error during request body writing: %w", err)
-	}
-
-	// prefix ASN1 header to SHA512 hash
-	digest := append(asn1Header, h.Sum(nil)...)
-
 	// prepare key struct
 	block, _ := pem.Decode(key)
 	if block == nil {
@@ -43,8 +29,9 @@ func signWithKey(body []byte, key []byte) (string, error) {
 	}
 
 	pkey := parsed.(*rsa.PrivateKey)
+	digest := sha512.Sum512(body)
 
-	enc, err := rsa.SignPKCS1v15(rand.Reader, pkey, crypto.Hash(0), digest)
+	enc, err := rsa.SignPKCS1v15(rand.Reader, pkey, crypto.SHA512, digest[:])
 	if err != nil {
 		return "", fmt.Errorf("could not sign data: %w", err)
 	}


### PR DESCRIPTION
### Short description
I noticed a small duplication of things crypto package already does. When supplying a Hash in SignPKCS1v15 it appends the same prefix. Also using Sum512 makes code lighter as no error checking (write function always returns null, probably interface thing) and no array duplication (which is used with sum).

### Checklist
<!-- Please check the boxes of the steps you took before making this PR -->
- [x] I read the [CONTRIBUTING.md](https://github.com/transip/gotransip/blob/master/CONTRIBUTING.md) document
- [x] This code actually compiles
- [x] This code solves my problem
- [x] I've updated the inline documentation
- [x] I added or modified test(s) to prevent this issue from ever occurring again

<!-- If your code doesn't make `go vet` or `go fmt` happy, Travis CI will complain and we can't merge your PR no matter how good it is. -->
