### PR TITLE
feat(vps): filter Operating Systems without needing a VPS.

### DIFF
--- a/vps/repository.go
+++ b/vps/repository.go
@@ -296,6 +296,16 @@ func (r *Repository) GetOperatingSystems(vpsName string) ([]OperatingSystem, err
 	return response.OperatingSystems, err
 }
 
+// FilterOperatingSystems allows you to filter Operating Systems without needing a VPS
+func (r *Repository) FilterOperatingSystems(productName string, addons []string) ([]OperatingSystem, error) {
+	var response operatingSystemsWrapper
+	requestBody := operatingSystemsRequest{ProductName: productName, Addons: addons}
+	restRequest := rest.Request{Endpoint: "/operating-systems", Body: &requestBody}
+	err := r.Client.Get(restRequest, &response)
+	fmt.Printf("%+v\n", response)
+	return response.OperatingSystems, err
+}
+
 // InstallOperatingSystem allows you to install an operating system to a Vps,
 // optionally you can specify a hostname and a base64InstallText,
 // which would be the automatic installation configuration of your Vps

--- a/vps/vps.go
+++ b/vps/vps.go
@@ -1,10 +1,11 @@
 package vps
 
 import (
+	"net"
+
 	"github.com/transip/gotransip/v6/ipaddress"
 	"github.com/transip/gotransip/v6/product"
 	"github.com/transip/gotransip/v6/rest"
-	"net"
 )
 
 // BackupStatus is one of the following strings
@@ -176,6 +177,13 @@ type upgradeRequest struct {
 // this is solely used for marshalling
 type upgradesWrapper struct {
 	Upgrades []product.Product `json:"upgrades"`
+}
+
+// operatingSystemsRequest struct contains a productName and an optional list of addons
+// this is solely used for marshalling
+type operatingSystemsRequest struct {
+	ProductName string   `json:"productName"`
+	Addons      []string `json:"addons,omitempty"`
 }
 
 // operatingSystemsWrapper struct contains a list with OperatingSystems in it,


### PR DESCRIPTION
### Short description
Adds filter API endpoint to allow for retrieving Operating Systems without needing a VPS. This can be particularly handy when no VPS is created yet, as is currently an open issue for the Terraform provider: https://github.com/aequitas/terraform-provider-transip/issues/74

### Checklist
<!-- Please check the boxes of the steps you took before making this PR -->
- [x] I read the [CONTRIBUTING.md](https://github.com/transip/gotransip/blob/master/CONTRIBUTING.md) document
- [x] This code actually compiles
- [x] This code solves my problem
- [x] I've updated the inline documentation
- [x] I added or modified test(s) to prevent this issue from ever occuring again